### PR TITLE
feat: 1.19.1/1.19.2 support

### DIFF
--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -34,6 +34,6 @@
   "depends": {
     "fabricloader": ">=0.13.3",
     "fabric": "*",
-    "minecraft": "1.19"
+    "minecraft": "1.19.x"
   }
 }


### PR DESCRIPTION
This pr changes `fabric.mod.json` to allow the mod to work on 1.19.1 and 1.19.2 as well. I've tested it out on my computer and everything seems to function correctly.
